### PR TITLE
DEX-71: Add deprecation notice pointing to Dexter 2.0 monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **Dexter has moved.** This repo is deprecated and no longer maintained. Development continues in the new monorepo: [cvburgess/dexter](https://github.com/cvburgess/dexter). Please file issues and follow development there.
+
 # Dexter - an opinionated day planner for Mac (and Web)
 
 ![Screenshot](https://dexterplanner.com/assets/screenshot-light.png)


### PR DESCRIPTION
## Summary
- Add an `[!IMPORTANT]` alert at the top of the README marking this repo as deprecated
- Point users to the new monorepo: [cvburgess/dexter](https://github.com/cvburgess/dexter)

This is the deprecation half of [DEX-71](https://linear.app/cvburgess/issue/DEX-71/open-source-deprecation-notice). The version bump and MIT open-sourcing land in a separate PR on `cvburgess/dexter`.

## Test plan
- [ ] README renders the `> [!IMPORTANT]` block as a GitHub alert
- [ ] The link resolves to `github.com/cvburgess/dexter`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a **GitHub `[!IMPORTANT]` alert** at the top of `README.md` so visitors see immediately that this repository is **deprecated and unmaintained**.
> 
> The notice directs users to continue development and file issues in the new monorepo at **`cvburgess/dexter`**. No application code, configuration, or build behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5277b4bb291f9e2c6fe5176ca4e843cb1865115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->